### PR TITLE
Minor fix env.py

### DIFF
--- a/config/env.py
+++ b/config/env.py
@@ -6,5 +6,5 @@ def get(key, default=None):
 
 
 def get_bool(key, default=None):
-    value = get(key, default).lower()
-    return value == 'true'
+    value = get(key, default)
+    return f'{value}'.lower() == 'true'


### PR DESCRIPTION
If you use default None or you get None you code is crashed in method get_bool at line 9.
You can use another solutions:

```
def get_bool(key, default=None):
    value = get(key, default)
    if not isinstance(value, str):
        return False
    return value.lower() == 'true'

def get_bool(key, default=None):
    value = get(key, default)
    if not hasattr(value, 'lower'):
        return False
    return value.lower() == 'true'

def get_bool(key, default=None):
    value = get(key, default)
    return str(value).lower() == 'true'
```
But if you don't use get_bool method in you code it's ok.